### PR TITLE
修改抛出的异常, 增加堆栈信息

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,5 +24,6 @@ try {
     module.exports = merge(CONFIG, require(filepath), false);
   }
 } catch (e) {
-  throw new Error('Cannot read config: ' + path.join(CONFIG_BASEDIR, CONFIG_DIR + '/' + id));
+	console.log('Cannot read config: ' + path.join(CONFIG_BASEDIR, CONFIG_DIR + '/' + id));
+	throw e;
 }


### PR DESCRIPTION
写配置文件配置出错的时候没有具体的堆栈信息难以定位, 修改抛出的错误, 方便定位.
